### PR TITLE
feat: add emit_scanner_valuer option for database/sql support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Add new `emit_scanner_valuer` option to generate `database/sql.Scanner` and
+  `database/sql/driver.Valuer` implementations for protobuf messages (#9). This is useful when
+  storing JSON representations of protobuf messages in database columns.
+
 ## [v1.5.0] - 2025-01-09
 
 - Correctly handle Protobuf Editions.

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ proto-buf: build
 
 proto-protoc: build
 	export PATH=$(CURDIR)/build/:$$PATH && \
-		protoc --go_out=. -I./e2e --go-json_out=orig_name=true:. e2e/*.proto
+		protoc --go_out=. -I./e2e --go-json_out=orig_name=true,emit_scanner_valuer=true:. e2e/*.proto

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ plugins:
     opt:
       - paths=source_relative
       - orig_name=true
+      - emit_scanner_valuer=true
 ```
 
 And then run:
@@ -151,6 +152,12 @@ for documentation on these options.
 | Option          | Description                               | Default |
 | --------------- | ----------------------------------------- | ------- |
 | `allow_unknown` | Disallow unknown fields when unmarshaling | `false` |
+
+#### Additional Options
+
+| Option                | Description                                                                                                              | Default |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `emit_scanner_valuer` | Generate `database/sql.Scanner` and `database/sql/driver.Valuer` implementations for storing protobuf messages in database JSON columns | `false` |
 
 It also includes the "standard" options available to all
 [protogen](https://pkg.go.dev/google.golang.org/protobuf/compiler/protogen?tab=doc)-based plugins:

--- a/e2e/e2e.pb.json.go
+++ b/e2e/e2e.pb.json.go
@@ -4,6 +4,9 @@
 package e2e
 
 import (
+	"database/sql/driver"
+	"fmt"
+
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -19,6 +22,35 @@ func (msg *Basic) UnmarshalJSON(b []byte) error {
 	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
 }
 
+// Scan implements database/sql.Scanner
+func (msg *Basic) Scan(src any) error {
+	if msg == nil {
+		return fmt.Errorf("Basic.Scan: nil receiver")
+	}
+	if src == nil {
+		*msg = Basic{}
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("Basic.Scan: expected []byte or string, got %T", src)
+	}
+	return msg.UnmarshalJSON(b)
+}
+
+// Value implements database/sql/driver.Valuer
+func (msg *Basic) Value() (driver.Value, error) {
+	if msg == nil {
+		return nil, nil
+	}
+	return msg.MarshalJSON()
+}
+
 // MarshalJSON implements json.Marshaler
 func (msg *Nested) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
@@ -31,6 +63,35 @@ func (msg *Nested) UnmarshalJSON(b []byte) error {
 	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
 }
 
+// Scan implements database/sql.Scanner
+func (msg *Nested) Scan(src any) error {
+	if msg == nil {
+		return fmt.Errorf("Nested.Scan: nil receiver")
+	}
+	if src == nil {
+		*msg = Nested{}
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("Nested.Scan: expected []byte or string, got %T", src)
+	}
+	return msg.UnmarshalJSON(b)
+}
+
+// Value implements database/sql/driver.Valuer
+func (msg *Nested) Value() (driver.Value, error) {
+	if msg == nil {
+		return nil, nil
+	}
+	return msg.MarshalJSON()
+}
+
 // MarshalJSON implements json.Marshaler
 func (msg *Nested_Message) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
@@ -41,4 +102,33 @@ func (msg *Nested_Message) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json.Unmarshaler
 func (msg *Nested_Message) UnmarshalJSON(b []byte) error {
 	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
+}
+
+// Scan implements database/sql.Scanner
+func (msg *Nested_Message) Scan(src any) error {
+	if msg == nil {
+		return fmt.Errorf("Nested_Message.Scan: nil receiver")
+	}
+	if src == nil {
+		*msg = Nested_Message{}
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("Nested_Message.Scan: expected []byte or string, got %T", src)
+	}
+	return msg.UnmarshalJSON(b)
+}
+
+// Value implements database/sql/driver.Valuer
+func (msg *Nested_Message) Value() (driver.Value, error) {
+	if msg == nil {
+		return nil, nil
+	}
+	return msg.MarshalJSON()
 }

--- a/e2e/e2e.pb.json.go
+++ b/e2e/e2e.pb.json.go
@@ -48,7 +48,11 @@ func (msg *Basic) Value() (driver.Value, error) {
 	if msg == nil {
 		return nil, nil
 	}
-	return msg.MarshalJSON()
+	b, err := msg.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
 }
 
 // MarshalJSON implements json.Marshaler
@@ -89,7 +93,11 @@ func (msg *Nested) Value() (driver.Value, error) {
 	if msg == nil {
 		return nil, nil
 	}
-	return msg.MarshalJSON()
+	b, err := msg.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
 }
 
 // MarshalJSON implements json.Marshaler
@@ -130,5 +138,9 @@ func (msg *Nested_Message) Value() (driver.Value, error) {
 	if msg == nil {
 		return nil, nil
 	}
-	return msg.MarshalJSON()
+	b, err := msg.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -117,7 +117,7 @@ func TestScannerValuer(t *testing.T) {
 		}
 		val, err := original.Value()
 		require.NoError(t, err)
-		require.IsType(t, []byte{}, val)
+		require.IsType(t, "", val)
 
 		got := new(Basic)
 		require.NoError(t, got.Scan(val))
@@ -129,11 +129,19 @@ func TestScannerValuer(t *testing.T) {
 		original := &Basic{A: "from-string", B: &Basic_Int{Int: 7}}
 		val, err := original.Value()
 		require.NoError(t, err)
+		require.IsType(t, "", val)
 
 		got := new(Basic)
-		require.NoError(t, got.Scan(string(val.([]byte))))
+		require.NoError(t, got.Scan(val))
 		require.Equal(t, original.GetA(), got.GetA())
 		require.Equal(t, original.GetInt(), got.GetInt())
+	})
+
+	t.Run("scan bytes input", func(t *testing.T) {
+		got := new(Basic)
+		require.NoError(t, got.Scan([]byte(`{"a":"from-bytes","int":9}`)))
+		require.Equal(t, "from-bytes", got.GetA())
+		require.Equal(t, int32(9), got.GetInt())
 	})
 
 	t.Run("scan nil resets message", func(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,10 +1,12 @@
 package e2e
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,4 +107,86 @@ func TestTable(t *testing.T) {
 			require.Equal(val.Interface(), expected)
 		})
 	}
+}
+
+func TestScannerValuer(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		original := &Basic{
+			A: "hello",
+			B: &Basic_Int{Int: 42},
+		}
+		val, err := original.Value()
+		require.NoError(t, err)
+		require.IsType(t, []byte{}, val)
+
+		got := new(Basic)
+		require.NoError(t, got.Scan(val))
+		require.Equal(t, original.GetA(), got.GetA())
+		require.Equal(t, original.GetInt(), got.GetInt())
+	})
+
+	t.Run("scan string input", func(t *testing.T) {
+		original := &Basic{A: "from-string", B: &Basic_Int{Int: 7}}
+		val, err := original.Value()
+		require.NoError(t, err)
+
+		got := new(Basic)
+		require.NoError(t, got.Scan(string(val.([]byte))))
+		require.Equal(t, original.GetA(), got.GetA())
+		require.Equal(t, original.GetInt(), got.GetInt())
+	})
+
+	t.Run("scan nil resets message", func(t *testing.T) {
+		optional := "set"
+		msg := &Basic{
+			A: "hello",
+			B: &Basic_Int{Int: 42},
+			O: &optional,
+		}
+		require.NoError(t, msg.Scan(nil))
+		require.Equal(t, &Basic{}, msg)
+	})
+
+	t.Run("scan unsupported type returns error", func(t *testing.T) {
+		msg := new(Basic)
+		err := msg.Scan(12345)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected []byte or string")
+	})
+
+	t.Run("nil receiver scan returns error", func(t *testing.T) {
+		var msg *Basic
+		err := msg.Scan([]byte(`{"a":"x"}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil receiver")
+	})
+
+	t.Run("nil receiver value returns nil", func(t *testing.T) {
+		var msg *Basic
+		val, err := msg.Value()
+		require.NoError(t, err)
+		require.Nil(t, val)
+	})
+
+	t.Run("valuer interface", func(t *testing.T) {
+		var _ driver.Valuer = (*Basic)(nil)
+		var _ driver.Valuer = (*Nested)(nil)
+		var _ driver.Valuer = (*Nested_Message)(nil)
+	})
+
+	t.Run("nested message round trip", func(t *testing.T) {
+		original := &Nested_Message{
+			Basic: &Basic{
+				A: "nested",
+				B: &Basic_Str{Str: "value"},
+			},
+		}
+		val, err := original.Value()
+		require.NoError(t, err)
+
+		got := new(Nested_Message)
+		require.NoError(t, got.Scan(val))
+		require.Equal(t, original.GetBasic().GetA(), got.GetBasic().GetA())
+		require.Equal(t, original.GetBasic().GetStr(), got.GetBasic().GetStr())
+	})
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -189,4 +189,186 @@ func TestScannerValuer(t *testing.T) {
 		require.Equal(t, original.GetBasic().GetA(), got.GetBasic().GetA())
 		require.Equal(t, original.GetBasic().GetStr(), got.GetBasic().GetStr())
 	})
+
+	t.Run("map fields round trip", func(t *testing.T) {
+		original := &Basic{
+			A:   "with-map",
+			Map: map[string]string{"key1": "val1", "key2": "val2"},
+		}
+		val, err := original.Value()
+		require.NoError(t, err)
+
+		got := new(Basic)
+		require.NoError(t, got.Scan(val))
+		require.Equal(t, original.GetMap(), got.GetMap())
+	})
+
+	t.Run("optional fields round trip", func(t *testing.T) {
+		present := "present"
+		original := &Basic{
+			A: "with-optional",
+			B: &Basic_Str{Str: "test"},
+			O: &present,
+		}
+		val, err := original.Value()
+		require.NoError(t, err)
+
+		got := new(Basic)
+		require.NoError(t, got.Scan(val))
+		require.NotNil(t, got.O)
+		require.Equal(t, present, *got.O)
+	})
+
+	t.Run("optional field absent round trip", func(t *testing.T) {
+		original := &Basic{
+			A: "no-optional",
+			B: &Basic_Int{Int: 1},
+		}
+		val, err := original.Value()
+		require.NoError(t, err)
+
+		got := new(Basic)
+		require.NoError(t, got.Scan(val))
+		require.Nil(t, got.O)
+	})
+
+	t.Run("oneof string variant round trip", func(t *testing.T) {
+		original := &Basic{
+			A: "oneof-str",
+			B: &Basic_Str{Str: "hello"},
+		}
+		val, err := original.Value()
+		require.NoError(t, err)
+
+		got := new(Basic)
+		require.NoError(t, got.Scan(val))
+		require.Equal(t, "hello", got.GetStr())
+		require.Equal(t, int32(0), got.GetInt())
+	})
+
+	t.Run("all fields populated round trip", func(t *testing.T) {
+		optional := "opt"
+		original := &Basic{
+			A:   "full",
+			B:   &Basic_Int{Int: 99},
+			Map: map[string]string{"a": "1", "b": "2"},
+			O:   &optional,
+		}
+		val, err := original.Value()
+		require.NoError(t, err)
+
+		got := new(Basic)
+		require.NoError(t, got.Scan(val))
+		require.Equal(t, original.GetA(), got.GetA())
+		require.Equal(t, original.GetInt(), got.GetInt())
+		require.Equal(t, original.GetMap(), got.GetMap())
+		require.NotNil(t, got.O)
+		require.Equal(t, optional, *got.O)
+	})
+
+	t.Run("reused receiver with partial json clears omitted fields", func(t *testing.T) {
+		optional := "set"
+		msg := &Basic{
+			A:   "seed",
+			B:   &Basic_Int{Int: 42},
+			Map: map[string]string{"k": "v"},
+			O:   &optional,
+		}
+
+		require.NoError(t, msg.Scan([]byte(`{"a":"only-a"}`)))
+		require.Equal(t, "only-a", msg.GetA())
+		require.Nil(t, msg.GetB())
+		require.Equal(t, int32(0), msg.GetInt())
+		require.Nil(t, msg.GetMap())
+		require.Nil(t, msg.O)
+	})
+
+	t.Run("reused receiver oneof switches variants", func(t *testing.T) {
+		msg := new(Basic)
+
+		require.NoError(t, msg.Scan([]byte(`{"int":7}`)))
+		require.Equal(t, int32(7), msg.GetInt())
+		require.Equal(t, "", msg.GetStr())
+
+		require.NoError(t, msg.Scan([]byte(`{"str":"seven"}`)))
+		require.Equal(t, "seven", msg.GetStr())
+		require.Equal(t, int32(0), msg.GetInt())
+
+		require.NoError(t, msg.Scan([]byte(`{"int":11}`)))
+		require.Equal(t, int32(11), msg.GetInt())
+		require.Equal(t, "", msg.GetStr())
+	})
+
+	t.Run("json null literal differs from sql null", func(t *testing.T) {
+		optional := "set"
+		msg := &Basic{
+			A:   "seed",
+			B:   &Basic_Int{Int: 42},
+			Map: map[string]string{"k": "v"},
+			O:   &optional,
+		}
+
+		require.NoError(t, msg.Scan(nil))
+		require.Equal(t, &Basic{}, msg)
+
+		msg = &Basic{
+			A:   "seed",
+			B:   &Basic_Int{Int: 42},
+			Map: map[string]string{"k": "v"},
+			O:   &optional,
+		}
+		err := msg.Scan([]byte("null"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected token null")
+		require.Equal(t, "", msg.GetA())
+		require.Nil(t, msg.GetB())
+		require.Nil(t, msg.GetMap())
+		require.Nil(t, msg.O)
+
+		msg = &Basic{
+			A:   "seed",
+			B:   &Basic_Int{Int: 42},
+			Map: map[string]string{"k": "v"},
+			O:   &optional,
+		}
+		err = msg.Scan("null")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected token null")
+		require.Equal(t, "", msg.GetA())
+		require.Nil(t, msg.GetB())
+		require.Nil(t, msg.GetMap())
+		require.Nil(t, msg.O)
+	})
+
+	t.Run("scan unknown field returns error", func(t *testing.T) {
+		msg := new(Basic)
+		err := msg.Scan([]byte(`{"a":"x","unknown":1}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown field")
+	})
+
+	t.Run("scan invalid payloads return error", func(t *testing.T) {
+		msg := new(Basic)
+		require.Error(t, msg.Scan([]byte(`{"map":"not-object"}`)))
+		require.Error(t, msg.Scan([]byte(`{"int":"abc"}`)))
+		require.Error(t, msg.Scan([]byte(`{"a":"x"`)))
+	})
+
+	t.Run("scan error allows subsequent successful scan on reused receiver", func(t *testing.T) {
+		msg := &Basic{
+			A: "seed",
+			B: &Basic_Int{Int: 42},
+		}
+		require.Error(t, msg.Scan([]byte(`{"int":"abc"}`)))
+		require.NoError(t, msg.Scan([]byte(`{"a":"ok","int":3}`)))
+		require.Equal(t, "ok", msg.GetA())
+		require.Equal(t, int32(3), msg.GetInt())
+	})
+
+	t.Run("nil receiver scan nil source returns error", func(t *testing.T) {
+		var msg *Basic
+		err := msg.Scan(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil receiver")
+	})
 }

--- a/internal/gen/template.go
+++ b/internal/gen/template.go
@@ -15,6 +15,7 @@ type Options struct {
 	EmitDefaultValues  bool
 	OrigName           bool
 	AllowUnknownFields bool
+	EmitScannerValuer  bool
 }
 
 // This function is called with a param which contains the entire definition of a method.
@@ -29,7 +30,8 @@ func ApplyTemplate(g *protogen.GeneratedFile, f *protogen.File, opts *Options) e
 	g.P()
 	genStandaloneComments(g, f, packageFieldNumber)
 	if err := headerTemplate.Execute(g, tplHeader{
-		File: f,
+		File:    f,
+		Options: opts,
 	}); err != nil {
 		return err
 	}
@@ -56,6 +58,7 @@ func applyMessages(w io.Writer, msgs []*protogen.Message, opts *Options) error {
 
 type tplHeader struct {
 	*protogen.File
+	*Options
 }
 
 type tplMessage struct {
@@ -68,6 +71,11 @@ var (
 package {{.GoPackageName}}
 
 import (
+	{{- if .EmitScannerValuer}}
+	"database/sql/driver"
+	"fmt"
+	{{- end}}
+
 	"google.golang.org/protobuf/encoding/protojson"
 )
 `))
@@ -99,6 +107,37 @@ func (msg *{{.GoIdent.GoName}}) UnmarshalJSON(b []byte) error {
 		{{- end}}
 	}.Unmarshal(b, msg)
 }
+{{- if .EmitScannerValuer}}
+
+// Scan implements database/sql.Scanner
+func (msg *{{.GoIdent.GoName}}) Scan(src any) error {
+	if msg == nil {
+		return fmt.Errorf("{{.GoIdent.GoName}}.Scan: nil receiver")
+	}
+	if src == nil {
+		*msg = {{.GoIdent.GoName}}{}
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("{{.GoIdent.GoName}}.Scan: expected []byte or string, got %T", src)
+	}
+	return msg.UnmarshalJSON(b)
+}
+
+// Value implements database/sql/driver.Valuer
+func (msg *{{.GoIdent.GoName}}) Value() (driver.Value, error) {
+	if msg == nil {
+		return nil, nil
+	}
+	return msg.MarshalJSON()
+}
+{{- end}}
 `))
 )
 

--- a/internal/gen/template.go
+++ b/internal/gen/template.go
@@ -135,7 +135,11 @@ func (msg *{{.GoIdent.GoName}}) Value() (driver.Value, error) {
 	if msg == nil {
 		return nil, nil
 	}
-	return msg.MarshalJSON()
+	b, err := msg.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
 }
 {{- end}}
 `))

--- a/internal/plugin/options.go
+++ b/internal/plugin/options.go
@@ -16,6 +16,8 @@ var supportedOptions = map[string]func(*gen.Options, string) error{
 	"orig_name":                  func(o *gen.Options, value string) error { return parseBool(&o.OrigName, value) },
 	// Unmarshal options
 	"allow_unknown": func(o *gen.Options, value string) error { return parseBool(&o.AllowUnknownFields, value) },
+	// Additional options
+	"emit_scanner_valuer": func(o *gen.Options, value string) error { return parseBool(&o.EmitScannerValuer, value) },
 }
 
 func parseOptions(raw string) (*gen.Options, error) {


### PR DESCRIPTION
This PR adds a new `emit_scanner_valuer` option that generates `database/sql.Scanner` and `database/sql/driver.Valuer` implementations on protobuf message types, enabling direct use with database JSON columns. 

Closes #9.